### PR TITLE
OverlayWindowコンポーネントを追加した

### DIFF
--- a/.changeset/friendly-dogs-sip.md
+++ b/.changeset/friendly-dogs-sip.md
@@ -1,0 +1,5 @@
+---
+"@shikakun/oden": minor
+---
+
+OverlayWindow コンポーネントを追加した

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -55,6 +55,8 @@ module.exports = {
         ],
       },
     ],
+    'react/jsx-uses-react': 'off',
+    'react/react-in-jsx-scope': 'off',
     'react-hooks/exhaustive-deps': 'error',
     'react-hooks/rules-of-hooks': 'error',
     'sort-imports': [

--- a/src/components/OverlayWindow/OverlayWindow.css.ts
+++ b/src/components/OverlayWindow/OverlayWindow.css.ts
@@ -1,0 +1,71 @@
+import { Color, Size } from '@shikakun/dashi';
+import { style } from '@vanilla-extract/css';
+
+const unset = style([
+  {
+    border: 'unset',
+    maxWidth: 'unset',
+    maxHeight: 'unset',
+    padding: 'unset',
+    margin: 'unset',
+  },
+  {
+    '::backdrop': {
+      background: 'unset',
+    },
+  },
+]);
+
+export const root = style([
+  unset,
+  {
+    position: 'fixed',
+    inset: 0,
+    height: '100lvh',
+    backgroundColor: 'transparent',
+    overflowY: 'scroll',
+  },
+]);
+
+export const container = style({
+  display: 'flex',
+});
+
+export const containerPositionBottom = style({
+  flexDirection: 'column-reverse',
+});
+
+export const body = style({
+  boxSizing: 'border-box',
+  position: 'relative',
+  backgroundColor: Color.background.page.light,
+});
+
+export const bodyPositionBottom = style({
+  width: '100vw',
+  minHeight: '50vh',
+});
+
+export const backdrop = style({
+  backgroundColor: 'rgba(0, 0, 0, 0.12)',
+});
+
+export const backdropPositionBottom = style({
+  height: '50vh',
+});
+
+export const closeButtonWrapper = style({
+  boxSizing: 'border-box',
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  height: '100%',
+  padding: Size.spacing.xs,
+  pointerEvents: 'none',
+});
+
+export const closeButtonContainer = style({
+  position: 'sticky',
+  top: Size.spacing.xs,
+  pointerEvents: 'auto',
+});

--- a/src/components/OverlayWindow/OverlayWindow.stories.tsx
+++ b/src/components/OverlayWindow/OverlayWindow.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { HiMiniXMark } from 'react-icons/hi2';
+import { Button } from '../Button';
+import { OverlayWindow } from './OverlayWindow';
+
+const meta: Meta<typeof OverlayWindow> = {
+  title: 'Components/OverlayWindow',
+  component: OverlayWindow,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const OverlayDemo: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
+
+  return (
+    <>
+      <Button onClick={handleOpen}>Open</Button>
+      <OverlayWindow
+        position='bottom'
+        isOpen={isOpen}
+        onClose={handleClose}
+        CloseIcon={HiMiniXMark}
+      >
+        <div style={{ padding: '1rem' }}>Overlay Content</div>
+      </OverlayWindow>
+    </>
+  );
+};
+
+export const InteractiveDemo: Story = {
+  render: () => <OverlayDemo />,
+};

--- a/src/components/OverlayWindow/OverlayWindow.tsx
+++ b/src/components/OverlayWindow/OverlayWindow.tsx
@@ -1,0 +1,89 @@
+import classNames from 'classnames';
+import React, { useRef } from 'react';
+import { IconType } from 'react-icons';
+import { Button } from '../Button';
+import * as styles from './OverlayWindow.css';
+
+export interface OverlayWindowProps {
+  // とりあえずbottomだけ用意する
+  position?: 'bottom';
+  isOpen?: boolean;
+  onClose?: () => void;
+  CloseIcon?: IconType;
+  closeLabel?: string;
+  children?: React.ReactNode;
+}
+
+export const OverlayWindow: React.FC<OverlayWindowProps> = ({
+  position = 'bottom',
+  isOpen = false,
+  onClose,
+  CloseIcon,
+  closeLabel = '閉じる',
+  children,
+  ...props
+}) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  React.useEffect(() => {
+    if (dialogRef.current) {
+      if (isOpen) {
+        dialogRef.current.showModal();
+        document.body.style.overflow = 'hidden';
+      } else {
+        dialogRef.current.close();
+        document.body.style.overflow = '';
+      }
+    }
+  }, [isOpen]);
+
+  const handleClose = () => {
+    dialogRef.current?.close();
+    onClose?.();
+  };
+
+  return (
+    <dialog
+      className={styles.root}
+      ref={dialogRef}
+      onClose={handleClose}
+      {...props}
+    >
+      <div
+        className={classNames(styles.container, {
+          [styles.containerPositionBottom]: position === 'bottom',
+        })}
+      >
+        <div
+          className={classNames(styles.body, {
+            [styles.bodyPositionBottom]: position === 'bottom',
+          })}
+        >
+          {children}
+          <div className={styles.closeButtonWrapper}>
+            <div className={styles.closeButtonContainer}>
+              <Button
+                onClick={handleClose}
+                Icon={CloseIcon ?? undefined}
+                shape='circle'
+                ariaLabel={closeLabel}
+              >
+                {closeLabel}
+              </Button>
+            </div>
+          </div>
+        </div>
+        <div
+          className={classNames(styles.backdrop, {
+            [styles.backdropPositionBottom]: position === 'bottom',
+          })}
+          aria-hidden='true'
+          role='button'
+          onClick={handleClose}
+        />
+      </div>
+    </dialog>
+  );
+};
+
+export default OverlayWindow;

--- a/src/components/OverlayWindow/index.ts
+++ b/src/components/OverlayWindow/index.ts
@@ -1,0 +1,2 @@
+import { OverlayWindow } from './OverlayWindow';
+export { OverlayWindow };


### PR DESCRIPTION
- OverlayWindowコンポーネントを追加しました。
    - dialog要素を使用しています。
    - コンテンツの型は定義せず、なんでも置けるようにしています。
- とりあえずハーフモーダルとしての用途を必要として `position: 'bottom'` のみ用意していますが、今後はドロワーメニューやモーダルダイアログの開発も想定しています。