### PR TITLE
reactとreact-domを外部モジュールとして扱いバンドルに含めないように指定した

### DIFF
--- a/.changeset/nervous-ravens-report.md
+++ b/.changeset/nervous-ravens-report.md
@@ -1,0 +1,5 @@
+---
+"@shikakun/oden": patch
+---
+
+react と react-dom を外部モジュールとして扱いバンドルに含めないように指定した

--- a/src/components/OverlayWindow/OverlayWindow.tsx
+++ b/src/components/OverlayWindow/OverlayWindow.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { IconType } from 'react-icons';
 import { Button } from '../Button';
 import * as styles from './OverlayWindow.css';
@@ -25,7 +25,7 @@ export const OverlayWindow: React.FC<OverlayWindowProps> = ({
 }) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (dialogRef.current) {
       if (isOpen) {
         dialogRef.current.showModal();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,5 +18,14 @@ export default defineConfig({
       name: 'oden',
       fileName: 'index',
     },
+    rollupOptions: {
+      external: ['react', 'react-dom'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
- Viteの設定を見直して、reactとreact-domを外部モジュールとして扱いバンドルに含めないように指定しました
- importの指定を揃えました