### PR TITLE
カスタムフックuseContainerSizeを追加した

### DIFF
--- a/.changeset/wet-onions-occur.md
+++ b/.changeset/wet-onions-occur.md
@@ -1,0 +1,5 @@
+---
+"@shikakun/oden": minor
+---
+
+カスタムフック useContainerSize を追加した

--- a/cspell.json
+++ b/cspell.json
@@ -1,3 +1,11 @@
 {
-  "ignoreWords": ["chikuwa", "dashi", "ganmodoki", "konjac", "oden", "shikakun"]
+  "ignoreWords": [
+    "autodocs",
+    "chikuwa",
+    "dashi",
+    "ganmodoki",
+    "konjac",
+    "oden",
+    "shikakun"
+  ]
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from './useContainerSize';

--- a/src/utilities/useContainerSize/index.ts
+++ b/src/utilities/useContainerSize/index.ts
@@ -1,0 +1,2 @@
+import { useContainerSize } from './useContainerSize';
+export { useContainerSize };

--- a/src/utilities/useContainerSize/useContainerSize.stories.tsx
+++ b/src/utilities/useContainerSize/useContainerSize.stories.tsx
@@ -1,0 +1,68 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useRef } from 'react';
+import { useContainerSize } from './useContainerSize';
+
+/**
+ * 特定のHTML要素の幅またはviewportの幅を取得し、幅の大きさによって以下の文字列を返すカスタムフックです。
+ *
+ * | 文字列 | 幅の範囲 |
+ * |----|----|
+ * | `2xs` | 〜329px |
+ * | `xs` | 330px〜369px |
+ * | `s` | 370px〜599px |
+ * | `m` | 600px〜799px |
+ * | `l` | 800px〜1099px |
+ * | `xl` | 1100px〜1399px |
+ * | `2xl` | 1400px〜 |
+ *
+ * ## 使い方
+ *
+ * ### 特定のHTML要素のサイズを取得する場合
+ *
+ * ```tsx
+ * import { useRef } from 'react';
+ * import { useContainerSize } from '@shikakun/oden';
+ *
+ * const MyComponent = () => {
+ *   const containerRef = useRef<HTMLDivElement>(null);
+ *   const containerSize = useContainerSize(containerRef);
+ *
+ *   return (
+ *     <div ref={containerRef}>
+ *       <p>現在のコンテナサイズ: {containerSize}</p>
+ *     </div>
+ *   );
+ * };
+ * ```
+ *
+ * ### viewportのサイズを取得する場合
+ *
+ * ```tsx
+ * import { useContainerSize } from '@shikakun/oden';
+ *
+ * const MyComponent = () => {
+ *   const viewportSize = useContainerSize();
+ *
+ *   return <p>現在のviewportサイズ: {viewportSize}</p>;
+ * };
+ * ```
+ */
+const meta: Meta = {
+  title: 'Utilities/useContainerSize',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const ContainerSizeDemo: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const size = useContainerSize(containerRef);
+
+  return size;
+};
+
+export const InteractiveDemo: Story = {
+  render: () => <ContainerSizeDemo />,
+};

--- a/src/utilities/useContainerSize/useContainerSize.ts
+++ b/src/utilities/useContainerSize/useContainerSize.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+export type ContainerSize = '2xs' | 'xs' | 's' | 'm' | 'l' | 'xl' | '2xl';
+
+const determineContainerSize = (width: number): ContainerSize => {
+  if (width < 330) return '2xs';
+  if (width < 370) return 'xs';
+  if (width < 600) return 's';
+  if (width < 800) return 'm';
+  if (width < 1100) return 'l';
+  if (width < 1400) return 'xl';
+  return '2xl';
+};
+
+export const useContainerSize = (
+  elementRef?: React.RefObject<HTMLElement>
+): ContainerSize => {
+  const [size, setSize] = useState<ContainerSize>('2xl');
+
+  useEffect(() => {
+    const updateSize = () => {
+      const width = elementRef?.current?.offsetWidth ?? window.innerWidth;
+      setSize(determineContainerSize(width));
+    };
+
+    updateSize();
+
+    const handleResize = () => updateSize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [elementRef]);
+
+  return size;
+};


### PR DESCRIPTION
特定のHTML要素の幅またはviewportの幅を取得し、幅の大きさによって以下の文字列を返すカスタムフックuseContainerSizeを追加しました。